### PR TITLE
Implement basic user auth and chat API

### DIFF
--- a/backend/internal/api/ai.go
+++ b/backend/internal/api/ai.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"likemind-backend/internal/models"
+	"likemind-backend/internal/services"
+)
+
+// RegisterAIRoutes exposes a simple AI generation endpoint
+func RegisterAIRoutes(rg *gin.RouterGroup, ai *services.AIService) {
+	rg.POST("/generate", func(c *gin.Context) {
+		var payload struct {
+			Message string `json:"message"`
+		}
+		if err := c.ShouldBindJSON(&payload); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		msg := []models.ChatMessage{{Role: "user", Content: payload.Message}}
+		resp, err := ai.GenerateResponse(c.Request.Context(), msg)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, resp)
+	})
+}

--- a/backend/internal/api/auth.go
+++ b/backend/internal/api/auth.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"likemind-backend/internal/services"
+)
+
+type registerRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Username string `json:"username" binding:"required"`
+	Password string `json:"password" binding:"required"`
+}
+
+type loginRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required"`
+}
+
+// RegisterAuthRoutes registers authentication endpoints
+func RegisterAuthRoutes(rg *gin.RouterGroup, auth *services.AuthService, users *services.UserService) {
+	rg.POST("/register", func(c *gin.Context) {
+		var req registerRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		user, err := users.CreateUser(req.Email, req.Username, req.Password)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		token, err := auth.GenerateToken(user)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"token": token})
+	})
+
+	rg.POST("/login", func(c *gin.Context) {
+		var req loginRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		user, err := users.ValidateCredentials(req.Email, req.Password)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+			return
+		}
+		token, err := auth.GenerateToken(user)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"token": token})
+	})
+}

--- a/backend/internal/api/chat.go
+++ b/backend/internal/api/chat.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"likemind-backend/internal/services"
+)
+
+// RegisterChatRoutes provides chat session and messaging endpoints
+func RegisterChatRoutes(rg *gin.RouterGroup, chat *services.ChatService) {
+	rg.GET("/sessions", func(c *gin.Context) {
+		uid, _ := c.Get("user_id")
+		userID := uint(uid.(float64))
+		sessions, err := chat.GetUserSessions(c.Request.Context(), userID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, sessions)
+	})
+
+	rg.POST("/sessions", func(c *gin.Context) {
+		uid, _ := c.Get("user_id")
+		userID := uint(uid.(float64))
+		var payload struct {
+			Title string `json:"title"`
+		}
+		if err := c.ShouldBindJSON(&payload); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		session, err := chat.CreateSession(c.Request.Context(), userID, payload.Title)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, session)
+	})
+
+	rg.GET("/sessions/:id/messages", func(c *gin.Context) {
+		sid, _ := strconv.Atoi(c.Param("id"))
+		msgs, err := chat.GetSessionMessages(c.Request.Context(), uint(sid))
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, msgs)
+	})
+
+	rg.POST("/sessions/:id/messages", func(c *gin.Context) {
+		sid, _ := strconv.Atoi(c.Param("id"))
+		var payload struct {
+			Message string `json:"message"`
+		}
+		if err := c.ShouldBindJSON(&payload); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		msg, err := chat.SendMessage(c.Request.Context(), uint(sid), payload.Message)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, msg)
+	})
+}

--- a/backend/internal/api/knowledge.go
+++ b/backend/internal/api/knowledge.go
@@ -1,0 +1,11 @@
+package api
+
+import "github.com/gin-gonic/gin"
+import "likemind-backend/internal/services"
+
+// RegisterKnowledgeRoutes is a placeholder
+func RegisterKnowledgeRoutes(rg *gin.RouterGroup, _ *services.SearchService) {
+	rg.GET("/documents", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "list documents"})
+	})
+}

--- a/backend/internal/api/search.go
+++ b/backend/internal/api/search.go
@@ -1,0 +1,11 @@
+package api
+
+import "github.com/gin-gonic/gin"
+import "likemind-backend/internal/services"
+
+// RegisterSearchRoutes provides placeholder search endpoints
+func RegisterSearchRoutes(rg *gin.RouterGroup, _ *services.SearchService) {
+	rg.GET("/history", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "search history"})
+	})
+}

--- a/backend/internal/api/user.go
+++ b/backend/internal/api/user.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"likemind-backend/internal/services"
+)
+
+// RegisterUserRoutes exposes user related endpoints
+func RegisterUserRoutes(rg *gin.RouterGroup, users *services.UserService) {
+	rg.GET("/me", func(c *gin.Context) {
+		idVal, exists := c.Get("user_id")
+		if !exists {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		idFloat, ok := idVal.(float64)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid id"})
+			return
+		}
+		user, err := users.GetByID(uint(idFloat))
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+			return
+		}
+		c.JSON(http.StatusOK, user)
+	})
+}

--- a/backend/internal/api/websocket.go
+++ b/backend/internal/api/websocket.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+
+	"likemind-backend/internal/services"
+)
+
+var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+// RegisterWebSocketRoutes registers basic websocket chat endpoint
+func RegisterWebSocketRoutes(rg *gin.RouterGroup, chat *services.ChatService) {
+	rg.GET("/chat", func(c *gin.Context) {
+		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			_, msg, err := conn.ReadMessage()
+			if err != nil {
+				break
+			}
+			chat.SendMessage(c.Request.Context(), 0, string(msg))
+			conn.WriteMessage(websocket.TextMessage, msg)
+		}
+	})
+}

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -1,0 +1,31 @@
+package services
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"gorm.io/gorm"
+
+	"likemind-backend/internal/models"
+)
+
+// AuthService handles authentication logic and JWT creation
+type AuthService struct {
+	db        *gorm.DB
+	jwtSecret string
+}
+
+func NewAuthService(db *gorm.DB, jwtSecret string) *AuthService {
+	return &AuthService{db: db, jwtSecret: jwtSecret}
+}
+
+func (s *AuthService) GenerateToken(user *models.User) (string, error) {
+	claims := jwt.MapClaims{
+		"user_id": user.ID,
+		"email":   user.Email,
+		"role":    user.Role,
+		"exp":     time.Now().Add(24 * time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(s.jwtSecret))
+}

--- a/backend/internal/services/search_service.go
+++ b/backend/internal/services/search_service.go
@@ -1,0 +1,8 @@
+package services
+
+// SearchService is a placeholder for future search features
+type SearchService struct{}
+
+func NewSearchService(_ string) *SearchService {
+	return &SearchService{}
+}

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -1,0 +1,62 @@
+package services
+
+import (
+	"fmt"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+
+	"likemind-backend/internal/models"
+)
+
+// UserService handles user related database operations
+type UserService struct {
+	db *gorm.DB
+}
+
+func NewUserService(db *gorm.DB) *UserService {
+	return &UserService{db: db}
+}
+
+// CreateUser registers a new user and hashes the password
+func (s *UserService) CreateUser(email, username, password string) (*models.User, error) {
+	hashed, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash password: %w", err)
+	}
+	user := &models.User{
+		Email:    email,
+		Username: username,
+		Password: string(hashed),
+	}
+	if err := s.db.Create(user).Error; err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+func (s *UserService) GetByEmail(email string) (*models.User, error) {
+	var user models.User
+	if err := s.db.Where("email = ?", email).First(&user).Error; err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+func (s *UserService) GetByID(id uint) (*models.User, error) {
+	var user models.User
+	if err := s.db.First(&user, id).Error; err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+func (s *UserService) ValidateCredentials(email, password string) (*models.User, error) {
+	user, err := s.GetByEmail(email)
+	if err != nil {
+		return nil, err
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {
+		return nil, fmt.Errorf("invalid credentials")
+	}
+	return user, nil
+}


### PR DESCRIPTION
## Summary
- add authentication and user services
- expose routes for auth, users and chat messaging
- include websocket endpoint and placeholder search/knowledge routes

## Testing
- `go build ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_686cd2c20b08832c9e9c1c6f9fd4342e