### PR TITLE
Add chat page UI

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -1,0 +1,10 @@
+import ChatInterface from '@/components/chat/ChatInterface'
+
+export default function ChatPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Messaging</h1>
+      <ChatInterface />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement Chat page under `/chat` using existing ChatInterface component

## Testing
- `npm install`
- `npm run build` *(fails: failed to fetch Inter font)*

------
https://chatgpt.com/codex/tasks/task_e_686cd043f048832cb81e4ebfbbbae145