### PR TITLE
Add docs and deployment assets

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 LikeMind
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1,0 +1,98 @@
+version: '3.8'
+
+services:
+  frontend:
+    image: likemind-frontend:latest
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_API_BASE_URL=/api
+      - NEXT_PUBLIC_WEBSOCKET_URL=/api
+    depends_on:
+      - backend
+    networks:
+      - likemind-network
+
+  backend:
+    image: likemind-backend:latest
+    restart: unless-stopped
+    environment:
+      - ENVIRONMENT=production
+      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/likemind?sslmode=disable
+      - REDIS_URL=redis://redis:6379
+      - JWT_SECRET=${JWT_SECRET}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - VECTOR_DB_URL=http://qdrant:6333
+    depends_on:
+      - postgres
+      - redis
+      - qdrant
+    networks:
+      - likemind-network
+
+  ai-service:
+    image: likemind-ai:latest
+    restart: unless-stopped
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - QDRANT_URL=http://qdrant:6333
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      - qdrant
+      - redis
+    networks:
+      - likemind-network
+
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: likemind
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - likemind-network
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+    networks:
+      - likemind-network
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    restart: unless-stopped
+    volumes:
+      - qdrant_data:/qdrant/storage
+    networks:
+      - likemind-network
+
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/conf.d:/etc/nginx/conf.d
+      - ./ssl:/etc/nginx/ssl
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - frontend
+      - backend
+      - ai-service
+    networks:
+      - likemind-network
+
+volumes:
+  postgres_data:
+  redis_data:
+  qdrant_data:
+
+networks:
+  likemind-network:
+    driver: bridge

--- a/deployment/k8s/backend-deployment.yaml
+++ b/deployment/k8s/backend-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: likemind-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: likemind-backend:latest
+          ports:
+            - containerPort: 8080

--- a/deployment/k8s/backend-service.yaml
+++ b/deployment/k8s/backend-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: likemind-backend
+spec:
+  type: ClusterIP
+  selector:
+    app: backend
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/deployment/monitoring/grafana/provisioning/datasources.yml
+++ b/deployment/monitoring/grafana/provisioning/datasources.yml
@@ -1,0 +1,8 @@
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deployment/monitoring/prometheus.yml
+++ b/deployment/monitoring/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'likemind-backend'
+    static_configs:
+      - targets: ['backend:8080']
+  - job_name: 'likemind-ai'
+    static_configs:
+      - targets: ['ai-service:8000']

--- a/deployment/nginx/conf.d/app.conf
+++ b/deployment/nginx/conf.d/app.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name _;
+
+    location /api/ {
+        proxy_pass http://backend:8080/;
+    }
+
+    location /ai/ {
+        proxy_pass http://ai-service:8000/;
+    }
+
+    location / {
+        proxy_pass http://frontend:3000/;
+    }
+}

--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -1,0 +1,20 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -1,0 +1,21 @@
+# AI Integration Guide
+
+The AI layer is built with FastAPI and integrates with OpenAI for language models and Qdrant for vector search.
+
+## Running Locally
+1. Install dependencies:
+   ```bash
+   cd ai-layer
+   pip install -r requirements.txt
+   ```
+2. Start the service:
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+The service listens on `http://localhost:8000` and exposes a `/health` endpoint for checks.
+
+## Environment Variables
+- `OPENAI_API_KEY` – your OpenAI key
+- `QDRANT_URL` – URL of the Qdrant instance
+- `REDIS_URL` – Redis connection string

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,27 @@
+# LikeMind API Documentation
+
+This document describes the main API endpoints provided by the backend service.
+
+## Authentication
+- `POST /api/v1/auth/register` – register a new user
+- `POST /api/v1/auth/login` – log in and receive a JWT token
+- `POST /api/v1/auth/refresh` – refresh an authentication token
+- `POST /api/v1/auth/logout` – invalidate the current token
+
+## Chat
+- `GET /api/v1/chat/sessions` – list chat sessions for the current user
+- `POST /api/v1/chat/sessions` – create a new chat session
+- `GET /api/v1/chat/sessions/:id/messages` – fetch messages in a session
+- `POST /api/v1/chat/sessions/:id/messages` – send a message to the AI
+
+## Search
+- `POST /api/v1/search/semantic` – perform a semantic search of the knowledge base
+- `GET /api/v1/search/history` – view recent searches
+- `POST /api/v1/search/index` – index documents for search
+
+## Knowledge Base
+- `GET /api/v1/knowledge/documents` – list uploaded documents
+- `POST /api/v1/knowledge/documents` – upload a new document
+- `DELETE /api/v1/knowledge/documents/:id` – remove a document
+
+WebSocket endpoints for real time chat and notifications are available under `/api/v1/ws/*`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,13 @@
+# Contributing to LikeMind
+
+Thank you for considering a contribution!
+
+1. Fork the repository and create a feature branch:
+   ```bash
+   git checkout -b feature/my-feature
+   ```
+2. Make your changes with clear commits.
+3. Ensure `go test ./...` and `npm run lint` pass where applicable.
+4. Open a pull request describing your changes.
+
+Bug reports and feature requests are welcome via GitHub issues.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,14 @@
+# Database Schema
+
+LikeMind uses PostgreSQL for relational data, Redis for caching, and Qdrant as a vector database.
+
+## PostgreSQL
+Tables are created automatically from the Go models using GORM migrations. Important tables include users, chat sessions, messages and knowledge documents.
+
+The initial schema can be found in `databases/postgresql/init.sql` and is executed automatically when running the Docker compose environment.
+
+## Redis
+Redis is used for caching chat history and other ephemeral data. The default configuration is provided in `databases/redis/redis.conf`.
+
+## Qdrant
+Qdrant stores vector embeddings for semantic search. The AI layer interacts with Qdrant directly.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,17 @@
+# Deployment Guide
+
+Docker compose files are provided to run the entire stack locally or in production.
+
+## Development
+Run the full stack including monitoring tools:
+```bash
+docker-compose -f deployment/docker-compose.yml up -d
+```
+
+## Production
+A simplified production compose file is available:
+```bash
+docker-compose -f deployment/docker-compose.prod.yml up -d
+```
+
+For Kubernetes deployments see the manifests under `deployment/k8s/`.


### PR DESCRIPTION
## Summary
- add docs folder referenced by README
- add production docker compose file
- add nginx and monitoring configs
- add example Kubernetes manifests
- add MIT license

## Testing
- `go mod tidy` *(fails: storage.googleapis.com blocked)*
- `go test ./...` *(fails: missing modules due to blocked dependencies)*
- `npm run lint` *(fails: `next` not installed)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686d19aa99b8832cb5e88e54937a13da